### PR TITLE
Enhance(EasyRdf Literal): Adding getter function to \EasyRdf\Literal class

### DIFF
--- a/lib/Literal.php
+++ b/lib/Literal.php
@@ -147,6 +147,26 @@ class Literal implements \JsonSerializable
         self::$classMap[$class] = $datatype;
     }
 
+    /** Retrieves the PHP class associated with the passed RDF datatype
+     *
+     * Example:
+     * \EasyRdf\Literal::getDatatypeMapping('xsd:date');
+     * returns '\EasyRdf\Literal\Date'
+     *
+     * @param string $datatype The datatype (e.g. xsd:date)
+     * @return string|null The string representation of the PHP class associated with the RDF datatype
+     * @throws \InvalidArgumentException
+     */
+    public static function getDatatypeMapping($datatype)
+    {
+        if (!\is_string($datatype) || (\is_string($datatype) && 0 == \strlen($datatype))) {
+            throw new \InvalidArgumentException('$datatype should be a string and cannot be null or empty');
+        }
+
+        $datatype = RdfNamespace::expand($datatype);
+        return self::$datatypeMap[$datatype] ?? null;
+    }
+
     /** Remove the mapping between an RDF datatype and a PHP class name
      *
      * @param string $datatype The RDF datatype (e.g. xsd:dateTime)

--- a/tests/EasyRdf/LiteralTest.php
+++ b/tests/EasyRdf/LiteralTest.php
@@ -430,6 +430,47 @@ class LiteralTest extends TestCase
         $this->assertStringEquals('', $literal->getLang());
     }
 
+    /** START */
+    public function testGetDatatypeMappingNull()
+    {
+        Literal::setDatatypeMapping('ex:mytype', MyDatatypeClass::class);
+        Literal::create('foobar', null, 'ex:mytype');
+
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage(
+            '$datatype should be a string and cannot be null or empty'
+        );
+
+        Literal::getDatatypeMapping(null);
+    }
+
+    public function testGetDatatypeMappingEmpty()
+    {
+        Literal::setDatatypeMapping('ex:mytype', MyDatatypeClass::class);
+        Literal::create('foobar', null, 'ex:mytype');
+
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage(
+            '$datatype should be a string and cannot be null or empty'
+        );
+
+        Literal::getDatatypeMapping('');
+    }
+
+    public function testGetDatatypeMappingNonString()
+    {
+        Literal::setDatatypeMapping('ex:mytype', MyDatatypeClass::class);
+        Literal::create('foobar', null, 'ex:mytype');
+
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage(
+            '$datatype should be a string and cannot be null or empty'
+        );
+
+        Literal::getDatatypeMapping([]);
+    }
+    /** END */
+
     public function testSetDatatypeMappingNull()
     {
         $this->expectException('InvalidArgumentException');

--- a/tests/EasyRdf/LiteralTest.php
+++ b/tests/EasyRdf/LiteralTest.php
@@ -469,6 +469,15 @@ class LiteralTest extends TestCase
         Literal::getDatatypeMapping([]);
     }
 
+    public function testGetDatatypeMappingNotExists()
+    {
+        Literal::setDatatypeMapping('ex:mytype', MyDatatypeClass::class);
+        Literal::create('foobar', null, 'ex:mytype');
+
+        $result = Literal::getDatatypeMapping('ex:test');
+        $this->assertSame($result, null);
+    }
+
     public function testSetDatatypeMappingNull()
     {
         $this->expectException('InvalidArgumentException');

--- a/tests/EasyRdf/LiteralTest.php
+++ b/tests/EasyRdf/LiteralTest.php
@@ -430,7 +430,6 @@ class LiteralTest extends TestCase
         $this->assertStringEquals('', $literal->getLang());
     }
 
-    /** START */
     public function testGetDatatypeMappingNull()
     {
         Literal::setDatatypeMapping('ex:mytype', MyDatatypeClass::class);
@@ -469,7 +468,6 @@ class LiteralTest extends TestCase
 
         Literal::getDatatypeMapping([]);
     }
-    /** END */
 
     public function testSetDatatypeMappingNull()
     {


### PR DESCRIPTION
# Enhance(EasyRdf Literal): Adding getter function to \EasyRdf\Literal class
Updates the \EasyRdf\Literal class to support a getDatatypeMapping() function to retrieve RDF type-to-class mappings.

# Why was this change made?
Feature request: https://github.com/SchemaApp/SchemaApp/issues/14894

# Links to any relevant tickets, articles, or other resources
Closes: https://github.com/SchemaApp/SchemaApp/issues/14894

# Other Notes
Added test cases to support new getter function.

# Setup Instructions and Suggested Tests for Reviewer
1. Clone the sweetrdf repo and checkout the PR branch 
2. Run `composer update` to install the test suite dependencies
3. Run the new tests for the LiteralTest.php file using `vendor/bin/phpunit tests/EasyRdf/LiteralTest.php`

# Final checks before you submit to reviewer
- [x] Is this Pull Request a small, discrete piece of functionality?
- [x] Is the code documented (code comments, appropriate wiki updates, is the readme up to date, etc.)
- [x] Have your Unit Tests all run and passed, and have you added edge cases?
- [x] Have you addressed all Codacy warnings and notifications?
- [x] Are all conflicts resolved with master?
- [x] Have you manually tested this on staging? (or wherever applicable)